### PR TITLE
Slave_AAS

### DIFF
--- a/src/algorithms/openmp/tbfopenmpalgorithm.hpp
+++ b/src/algorithms/openmp/tbfopenmpalgorithm.hpp
@@ -108,7 +108,7 @@ protected:
 
                 auto* kernelsPtr = kernels.data();
 
-#pragma omp task depend(in:ptr_lowerGroupGetMultipolePtr[0]) depend(commute:ptr_upperGroupGetMultipolePtr[0]) default(shared) firstprivate(upperGroup, lowerGroup, kernelsPtr)  priority(priorities.getM2MPriority(idxLevel))
+#pragma omp task depend(in:ptr_lowerGroupGetMultipolePtr[0]) depend(commute:ptr_upperGroupGetMultipolePtr[0]) default(shared) firstprivate(idxLevel, upperGroup, lowerGroup, kernelsPtr)  priority(priorities.getM2MPriority(idxLevel))
                 {
                     kernelWrapper.M2M(idxLevel, kernelsPtr[omp_get_thread_num()], *lowerGroup, *upperGroup);
                 }

--- a/src/algorithms/openmp/tbfopenmpalgorithm.hpp
+++ b/src/algorithms/openmp/tbfopenmpalgorithm.hpp
@@ -81,6 +81,8 @@ protected:
 
     template <class TreeClass>
     void M2M(TreeClass& inTree){
+        assert(stopUpperLevel >= 0);
+        assert(configuration.getTreeHeight() > stopUpperLevel);
         for(long int idxLevel = configuration.getTreeHeight()-2 ; idxLevel >= stopUpperLevel ; --idxLevel){
             auto& upperCellGroup = inTree.getCellGroupsAtLevel(idxLevel);
             const auto& lowerCellGroup = inTree.getCellGroupsAtLevel(idxLevel+1);
@@ -128,6 +130,8 @@ protected:
     void M2L(TreeClass& inTree){
         const auto& spacialSystem = inTree.getSpacialSystem();
 
+        assert(stopUpperLevel >= 0);
+        assert(configuration.getTreeHeight() > stopUpperLevel);
         for(long int idxLevel = stopUpperLevel ; idxLevel <= configuration.getTreeHeight()-1 ; ++idxLevel){
             auto& cellGroups = inTree.getCellGroupsAtLevel(idxLevel);
 

--- a/src/tbfglobal.hpp
+++ b/src/tbfglobal.hpp
@@ -12,7 +12,13 @@ template <class RealType>
 using TbfDefaultSpaceIndexType = TbfMortonSpaceIndex<3, TbfSpacialConfiguration<RealType, 3>, false>;
 
 template <class RealType>
+using TbfDefaultSpaceIndexType2D = TbfMortonSpaceIndex<3, TbfSpacialConfiguration<RealType, 2>, false>;
+
+template <class RealType>
 using TbfDefaultSpaceIndexTypePeriodic = TbfMortonSpaceIndex<3, TbfSpacialConfiguration<RealType, 3>, true>;
+
+template <class RealType>
+using TbfDefaultSpaceIndexTypePeriodic2D = TbfMortonSpaceIndex<3, TbfSpacialConfiguration<RealType, 2>, true>;
 
 constexpr static long int TbfDefaultMemoryAlignement = 64;
 


### PR DESCRIPTION
segFault problem at testRotationKernel is fixed when compiled by g++ with openMP.

Some defualt names are introduced for a 2D space (to used in future development)

asserts added