### PR TITLE
dangling refs fix keeping the performance

### DIFF
--- a/src/core/tbfcellscontainer.hpp
+++ b/src/core/tbfcellscontainer.hpp
@@ -247,19 +247,23 @@ public:
         //                return std::optional<long int>(idxCell);
         //            }
         //        }
-        const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        
+        // const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        const auto nbCells{objectData.template getViewerForBlockConst<0>().getItem().nbCells};
 
-        const long int idxCell = TbfUtils::lower_bound_indexes( 0, header.nbCells, inIndex, [this](const auto& idxCellIterate, const auto& index){
-            const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCellIterate);
-            return cellHeader.spaceIndex < index;
+        const long int idxCell = TbfUtils::lower_bound_indexes(0, nbCells, inIndex, [this](const auto& idxCellIterate, const auto& index){
+          //  const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCellIterate);
+          const auto spaceIndex{objectData.template getViewerForBlockConst<1>().getItem(idxCellIterate).spaceIndex};
+            return spaceIndex < index;
         });
 
-        if(idxCell == header.nbCells){
+        if(idxCell == nbCells){
             return std::nullopt;
         }
 
-        const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCell);
-        if(cellHeader.spaceIndex != inIndex){
+        // const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCell);
+        const auto spaceIndex{objectData.template getViewerForBlockConst<1>().getItem(idxCell).spaceIndex};
+        if(spaceIndex != inIndex){
             return std::nullopt;
         }
 

--- a/src/core/tbfcellscontainer.hpp
+++ b/src/core/tbfcellscontainer.hpp
@@ -280,19 +280,22 @@ public:
         //                return std::optional<long int>(idxCell);
         //            }
         //        }
-        const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        // const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        const auto nbCells{objectData.template getViewerForBlockConst<0>().getItem().nbCells};
 
-        const long int idxCell = TbfUtils::lower_bound_indexes( 0, header.nbCells, inParentIndex, [this, &spaceSystem](const auto& idxCellIterate, const auto& parentIndex){
-            const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCellIterate);
-            return (spaceSystem.getParentIndex(cellHeader.spaceIndex) < parentIndex);
+        const long int idxCell = TbfUtils::lower_bound_indexes( 0, nbCells, inParentIndex, [this, &spaceSystem](const auto& idxCellIterate, const auto& parentIndex){
+            // const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCellIterate);
+            const auto spaceIndex{objectData.template getViewerForBlockConst<1>().getItem(idxCellIterate).spaceIndex};
+            return (spaceSystem.getParentIndex(spaceIndex) < parentIndex);
         });
 
-        if(idxCell == header.nbCells){
+        if(idxCell == nbCells){
             return std::nullopt;
         }
 
-        const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCell);
-        if(spaceSystem.getParentIndex(cellHeader.spaceIndex) != inParentIndex){
+        // const CellHeader& cellHeader = objectData.template getViewerForBlockConst<1>().getItem(idxCell);
+        const auto spaceIndex{objectData.template getViewerForBlockConst<1>().getItem(idxCell).spaceIndex};
+        if(spaceSystem.getParentIndex(spaceIndex) != inParentIndex){
             return std::nullopt;
         }
 

--- a/src/core/tbfparticlescontainer.hpp
+++ b/src/core/tbfparticlescontainer.hpp
@@ -312,15 +312,16 @@ const long int* getParticleIndexes(const long int inIdxLeaf) const {
         //                return std::optional<long int>(idxLeaf);
         //            }
         //        }
-        const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        // const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        const auto nbLeaves{objectData.template getViewerForBlockConst<0>().getItem().nbLeaves};
         auto leavesViewer = objectData.template getViewerForBlockConst<1>();
 
-        const long int idxLeaf = TbfUtils::lower_bound_indexes( 0, header.nbLeaves, inIndex, [&leavesViewer](const auto& idxLeafIterate, const auto& index){
+        const long int idxLeaf = TbfUtils::lower_bound_indexes( 0, nbLeaves, inIndex, [&leavesViewer](const auto& idxLeafIterate, const auto& index){
             const auto& leafHeader = leavesViewer.getItem(idxLeafIterate);
             return (leafHeader.spaceIndex < index);
         });
 
-        if(idxLeaf == header.nbLeaves){
+        if(idxLeaf == nbLeaves){
             return std::nullopt;
         }
 
@@ -413,11 +414,12 @@ const long int* getParticleIndexes(const long int inIdxLeaf) const {
 
     template <class FuncClass>
     void applyToAllLeaves(FuncClass&& inFunc) {
-        const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        // const ContainerHeader& header = objectData.template getViewerForBlockConst<0>().getItem();
+        const auto nbLeaves{objectData.template getViewerForBlockConst<0>().getItem().nbLeaves};
 
         auto leavesViewer = objectData.template getViewerForBlock<1>();
 
-        for(long int idxLeaf = 0 ; idxLeaf < header.nbLeaves ; ++idxLeaf){
+        for(long int idxLeaf = 0 ; idxLeaf < nbLeaves ; ++idxLeaf){
             auto& leafHeader = leavesViewer.getItem(idxLeaf);
 
             long int* particleIndexes = &objectData.template getViewerForBlock<2>().getItem(leafHeader.offSet);


### PR DESCRIPTION
This branch is my **last** attempt to fix the issue with dangling references.
I just picked concrete values from the structure retrieved by `getItem()` method.
The `const&` to this struct is not required essentially.

Particular lines of code are slightly longer now (a drawback),
but the gcc compiler is satisfied (an advantage).

If you do not accept it by any reason,
I would not bother you with this issue anymore.

Thank you for your time!

_A run of unit-tests may be required_
to be sure that behavior was not changed.